### PR TITLE
Added support for PhantomJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ var reporter = require('./lib/reporter');
 var PLUGIN_NAME = 'gulp-axe-core';
 require('chromedriver');
 
+//setup custom phantomJS capability
+const phantomjs_exe = require('phantomjs-prebuilt').path;
+var customPhantom = WebDriver.Capabilities.phantomjs();
+customPhantom.set("phantomjs.binary.path", phantomjs_exe);
+
 var promise;
 var results = [];
 
@@ -24,10 +29,11 @@ module.exports = function (customOptions) {
 	};
 
 	var options = customOptions ? Object.assign(defaultOptions, customOptions) : defaultOptions;
-	var driver = new WebDriver.Builder().forBrowser(options.browser).build();
+	var driver = options.browser === 'phantomjs' ? new WebDriver.Builder().withCapabilities(customPhantom).build() :
+    new WebDriver.Builder().forBrowser(options.browser).build();
 
 	var createResults = function(cb) {
-		
+
 		var dest = '';
 		if(options.saveOutputIn !== '') {
 			dest = path.join(options.folderOutputReport, options.saveOutputIn);
@@ -35,11 +41,11 @@ module.exports = function (customOptions) {
 		}
 		driver.quit();
 		cb();
-		
+
 	};
 
 	var bufferContents = function (file, enc, cb) {
-		
+
 		if (file.isNull()) {
 			cb(null, file);
 			return;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "file-url": "^1.1.0",
     "fs-extra": "^0.30.0",
     "fs-path": "0.0.22",
+    "phantomjs-prebuilt": "^2.1.12",
     "promise": "^7.1.1",
     "selenium-webdriver": "^2.53.3",
     "through2": "^0.6.5"
@@ -51,7 +52,6 @@
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.1.0",
     "mocha": "^2.4.5",
-    "phantomjs-prebuilt": "^2.1.12",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.5",
     "should": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.1.0",
     "mocha": "^2.4.5",
+    "phantomjs-prebuilt": "^2.1.12",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.5",
     "should": "^8.3.0",


### PR DESCRIPTION
Added phantomjs-prebuilt as a dependency. Using 'phantomjs' as browser option allows tests to be run headless.

E.g. `var options = { browser: 'phantomjs' };`