### PR TITLE
A11y check options

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ module.exports = function (customOptions) {
 		browser: 'chrome',
 		folderOutputReport: 'aXeReports',
 		saveOutputIn: '',
-		threshold: 0
+		threshold: 0,
+		a11yCheckOptions: {}
 	};
 
 	var options = customOptions ? Object.assign(defaultOptions, customOptions) : defaultOptions;
@@ -61,6 +62,7 @@ module.exports = function (customOptions) {
 					driver.get(fileUrl(file.path)).then(function() {
 						var startTimestamp = new Date().getTime();
 						new AxeBuilder(driver)
+							.options(options.a11yCheckOptions)
 							.analyze(function(result) {
 								result.url = file.path;
 								result.timestamp = new Date().getTime();

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   ],
   "dependencies": {
     "axe-core": "^2.0.5",
-    "axe-webdriverjs": "^0.3.0",
+    "axe-webdriverjs": "^0.4.0",
     "chromedriver": "^2.23.0",
     "file-url": "^1.1.0",
     "fs-extra": "^0.30.0",
     "fs-path": "0.0.22",
     "phantomjs-prebuilt": "^2.1.12",
     "promise": "^7.1.1",
-    "selenium-webdriver": "^2.53.3",
+    "selenium-webdriver": "^3.0.0",
     "through2": "^0.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update axe-webdriverjs and selenium-webdriver packages
- Add the ability to pass axe-core a set of a11yCheck options as per:
  - https://github.com/dequelabs/axe-webdriverjs#axebuilderoptionsoptionsobject
  - https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axea11ycheck

Essentially this will allow a user of this package to customise the tests they want axe to run for their given project. Excluding rules, only running certain rules, only running to a certain level etc.